### PR TITLE
[WIP] Moves sqlite database to a separate volume 

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -18,6 +18,7 @@ jobs:
       steps:
         - uses: actions/checkout@v3
         - uses: superfly/flyctl-actions/setup-flyctl@master
+        # - run: fly volumes create adyencheckout_data --region ams (run only once)
         - run: flyctl secrets set ADYEN_API_KEY="$ADYEN_API_KEY"
         - run: flyctl secrets set ADYEN_CLIENT_KEY="$ADYEN_CLIENT_KEY"
         - run: flyctl secrets set ADYEN_HMAC_KEY="$ADYEN_HMAC_KEY"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Remember to include `http://localhost:8080` in the list of Allowed Origins
     ADYEN_HMAC_KEY="your_hmac_key_here"
 ```
 
+4. In order to save and load configuration, the application makes use of an sqlite database. By default, the sqlite database will be created in the root of the application folder, but this can be changed (for example to make it persistent). You can change the default location by adding a `DATABASE_LOCATION` value in the `.env` file.
+
+```
+   DATABASE_LOCATION="/data"
+```
+
 ## Usage
 1. Run `./start.sh` to:
    - Initialize the required environment variables. This step is necessary every time you re-activate your venv

--- a/app/app.py
+++ b/app/app.py
@@ -186,7 +186,7 @@ def create_app():
         return send_from_directory(os.path.join(app.root_path, 'static'),
                                    'img/favicon.ico')
                                 
-    initialise_db(app.root_path)
+    initialise_db("/data")
 
     return app
 

--- a/app/app.py
+++ b/app/app.py
@@ -186,7 +186,7 @@ def create_app():
         return send_from_directory(os.path.join(app.root_path, 'static'),
                                    'img/favicon.ico')
                                 
-    initialise_db("/data")
+    initialise_db(get_database_location())
 
     return app
 

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -5,6 +5,9 @@ from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
 
+def get_database_location():
+    return os.environ.get("DATABASE_LOCATION", "/")
+
 def get_port():
     return os.environ.get("PORT", 8080)
 

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,10 @@ processes = []
 
 [env]
 
+[mounts]
+  source="adyencheckout_data"
+  destination="/data"
+
 [experimental]
   allowed_public_ports = []
   auto_rollback = true


### PR DESCRIPTION
To avoid constant removal of the sqlite database, I created a fly.io [volume](https://fly.io/docs/reference/volumes/#using-volumes) for it. 

I have not been able to test it though, so once this is merged we might have surprises. Also worth mentioning that once this is deployed, the currently db will be nuked. What we could do is do a get call on eahc of the ids you know exist in the current db (`/loadConfig`, and `loadStyles`), save them somewhere in a text file, given they're just json and then run `saveConfig` again once the new db is deployed. 

With volumes, the db will not be nuked any more. However, it won't be easy to access like a file system, only via the app. If we want this, we might want to switch to an online solution like firebase; but keepingin mind it will require more setup for customers who might want to run this locally.
